### PR TITLE
Build the latest versioned and tagged release, rather than the latest…

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,7 @@ parts:
     source-type: git
     override-build: |
       # build the latest tagged release
-      latest_tag=$(git tag --list | grep '^v' | tail -1)
+      latest_tag=$(git tag --list | grep '^v' | sort -V | tail -1)
       git checkout ${latest_tag?}
       snapcraftctl set-version $(git describe --tags)
       make install

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,6 @@ parts:
       # build the latest tagged release
       latest_tag=$(git tag --list | grep '^v' | sort -V | tail -1)
       git checkout ${latest_tag?}
-      snapcraftctl set-version $(git describe --tags)
+      craftctl set version=$(git describe --tags)
       make install
     source: https://github.com/tingdahl/tflint.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ summary: Linter for terraform definitions
 description: >
       The tflint from https://github.com/terraform-linters/tflint . 
       The the snap should follow the upstream project.
-version: git
+adopt-info: tflint
 source-code: https://github.com/tingdahl/tflint.git
 grade: stable
 base: core22
@@ -28,5 +28,10 @@ parts:
       - GOBIN: "$CRAFT_PRIME"
     build-snaps: [go]
     source-type: git
-    override-build: make install
+    override-build: |
+      # build the latest tagged release
+      latest_tag=$(git tag --list | grep '^v' | tail -1)
+      git checkout ${latest_tag?}
+      snapcraftctl set-version $(git describe --tags)
+      make install
     source: https://github.com/tingdahl/tflint.git


### PR DESCRIPTION
This won't do much on its own as we're not syncing tags from upstream in this repo, but it seems like a more conservative approach to snap the latest release, than just building the latest commit.

If we do particularly want to do the latter, perhaps that could be published to a beta/edge branch rather than `latest/stable`.